### PR TITLE
[ONMEET-50] 아고라 접속시 다른 사람이 보이지 않아요

### DIFF
--- a/src/components/MeetingPage/MeetingRoom.tsx
+++ b/src/components/MeetingPage/MeetingRoom.tsx
@@ -224,7 +224,7 @@ const MeetingRoom = ({
         />
       )}
 
-      {ready && track && (
+      {start && track && (
         <Controls
           track={track}
           trackState={trackState}


### PR DESCRIPTION
변경사항
1. 아고라 접속시 아고라 loading 완료 시점 전에 mic off를 하는 경우, 아고라에서 Error 발생.
2. 이 부분을 수정하기 위해 아고라 loading 완료 시점에 mic on/off 버튼을 출력하는 형태로 변경