### PR TITLE
[ONMEET-63] 랜동모 홈 UI를 수정해요

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import CreateMeetingForm from './components/CreateMeetingPage/CreateMeetingForm'
 import LandingPage from './components/LandingPage';
 import LinkGeneratorPage from './components/LinkGeneratorPage';
 import MeetingDetailPage from './components/MeetingDetailPage';
+import MeetingListPage from './components/MeetingListPage';
 import MyPage from './components/MyPage';
 import GuidePage from './components/ServiceGuidePage/GuidePage';
 import useMini from './hook/useMini';
@@ -54,6 +55,7 @@ const App: React.FC = () => {
       >
         <ToastContainer position="bottom-center" delay={2000} />
         <Screen path="/" component={LandingPage} />
+        <Screen path="/home" component={MeetingListPage} />
         <Screen path="/generator" component={LinkGeneratorPage} />
         <Screen path="/guide/create" component={CreateGuidePage} />
         <Screen path="/guide/service" component={GuidePage} />

--- a/src/components/MeetingListPage/index.tsx
+++ b/src/components/MeetingListPage/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const MeetingListPage: React.FC = () => {
+  return <div className="meeting-list"></div>;
+};
+
+export default MeetingListPage;


### PR DESCRIPTION
**변경사항**
1. 새로운 페이지 분리 
    - 기존 홈 페이지에서 필요없는 기능이 많아지고, 새롭게 개편하는 방향이 빠를 것 같아 새로운 컴포넌트로 분리했어요.
  

2. 페이지 이름 변경 
    - 현재 홈으로 사용하고있는 컴포넌트 이름이 `LandingPage.tsx` 인데, 랜딩페이지라는 워드가 서비스 접속 시에 보여지는 페이지 라는 의미인데 해당 페이지에 대해 직관적으로 이해할 수 있는 네이밍은 아니라고 생각해서 `MeetingListPage.tsx` 로 더 명확한 의미의 이름으로 변경했어요.