### PR TITLE
:recycle: 종료된 모임 분기해 보여주도록 수정

### DIFF
--- a/src/components/Home/components/EmptyMeeting.tsx
+++ b/src/components/Home/components/EmptyMeeting.tsx
@@ -15,7 +15,6 @@ function EmptyMeeting({ className }: Props): ReactElement {
 
   return (
     <EmptyWrapper className={className}>
-      <Spacing height="6rem" />
       <EmptyText>
         {'현재 진행중인 모임이 없어요.\n지금 모임을 만들고 이웃을 만나보세요.'}
       </EmptyText>
@@ -34,6 +33,7 @@ const EmptyWrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  margin: 5.6rem 0;
 `;
 
 const EmptyText = styled.div`

--- a/src/components/Home/components/MeetingList/FinishMeetingList.tsx
+++ b/src/components/Home/components/MeetingList/FinishMeetingList.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import Divider from '@components/common/Divider';
+import styled from '@emotion/styled';
+import { MeetingList } from 'meeting-v2';
+
+import MeetingCard from '../MeetingCard';
+import Spacing from '../Spacing';
+import LineDivider from './LineDivider';
+
+type Props = {
+  meetings: MeetingList[];
+};
+
+function FinishMeetingList({ meetings }: Props) {
+  const existMeeting = meetings.length !== 0;
+  return existMeeting ? (
+    <section>
+      <Divider size="0.1rem" color="rgba(33, 33, 36, 0.07)" />
+      <Spacing height="3.2rem" />
+      <Title>지난 모임방</Title>
+      {meetings.map(meeting => (
+        <div key={meeting.id}>
+          <MeetingCard key={meeting.id} {...meeting} />
+          <LineDivider />
+        </div>
+      ))}
+    </section>
+  ) : null;
+}
+
+const Title = styled.h2`
+  font-size: 1.8rem;
+  line-height: 2.2rem;
+  letter-spacing: -0.04rem;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.$gray900};
+`;
+
+export default FinishMeetingList;

--- a/src/components/Home/components/MeetingList/LiveMeetingList.tsx
+++ b/src/components/Home/components/MeetingList/LiveMeetingList.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { MeetingList } from 'meeting-v2';
+
+import EmptyMeeting from '../EmptyMeeting';
+import MeetingCard from '../MeetingCard';
+import Spacing from '../Spacing';
+import LineDivider from './LineDivider';
+
+type Props = {
+  meetings: MeetingList[];
+};
+
+function LiveMeetingList({ meetings }: Props) {
+  const existMeeting = meetings.length !== 0;
+  return (
+    <section>
+      {existMeeting ? (
+        <>
+          <Spacing height="1.6rem" />
+          {meetings.map(meeting => (
+            <div key={meeting.id}>
+              <MeetingCard key={meeting.id} {...meeting} />
+              <LineDivider />
+            </div>
+          ))}
+        </>
+      ) : (
+        <EmptyMeeting />
+      )}
+    </section>
+  );
+}
+
+export default LiveMeetingList;

--- a/src/components/Home/components/MeetingList/index.tsx
+++ b/src/components/Home/components/MeetingList/index.tsx
@@ -1,20 +1,16 @@
 import React from 'react';
 
 import useGetMeetingList from '../../hook/useGetMeetingList';
-import MeetingCard from '../MeetingCard';
-import LineDivider from './LineDivider';
+import FinishMeetingList from './FinishMeetingList';
+import LiveMeetingList from './LiveMeetingList';
 
 function MeetingList() {
-  const { meetings } = useGetMeetingList();
+  const { liveMeetings, finishMeetings } = useGetMeetingList();
 
   return (
     <section>
-      {meetings.map(meeting => (
-        <div key={meeting.id}>
-          <MeetingCard key={meeting.id} {...meeting} />
-          <LineDivider />
-        </div>
-      ))}
+      {liveMeetings && <LiveMeetingList meetings={liveMeetings} />}
+      {finishMeetings && <FinishMeetingList meetings={finishMeetings} />}
     </section>
   );
 }

--- a/src/components/Home/hook/useGetMeetingList.ts
+++ b/src/components/Home/hook/useGetMeetingList.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { getMeetings } from '@api/v2/meeting';
 import { useQueryParams } from '@karrotframe/navigator';
@@ -21,7 +21,15 @@ const useGetMeetingList = () => {
     meetingListHandler({ setMeetings });
   }, [queryParams, setMeetings, detailMeetingId]);
 
-  return { meetings };
+  const liveMeetings = useMemo(() => {
+    return meetings.filter(meeting => meeting.live_status === 'live');
+  }, [meetings]);
+
+  const finishMeetings = useMemo(() => {
+    return meetings.filter(meeting => meeting.live_status === 'finish');
+  }, [meetings]);
+
+  return { meetings, liveMeetings, finishMeetings };
 };
 
 export const meetingListHandler = async ({

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -11,23 +11,21 @@ import { analytics } from '../../App';
 import CustomScreenHelmet from '../common/CustomScreenHelmet';
 import Banner from './components/Banner';
 import DetailSheet from './components/DetailSheet';
-import EmptyMeeting from './components/EmptyMeeting';
 import FloatWrapper from './components/FloatWrapper';
 import MeetingList from './components/MeetingList';
 import PageTitle from './components/PageTitle';
 import Spacing from './components/Spacing';
-import useGetMeetingList from './hook/useGetMeetingList';
 import useMeetingDetail from './hook/useMeetingDetail';
 
-type MainProps = { existMeetings: boolean };
-
-const MainContents = ({ existMeetings }: MainProps) => {
-  return <main>{existMeetings ? <MeetingList /> : <EmptyMeeting />}</main>;
+const MainContents = () => {
+  return (
+    <main>
+      <MeetingList />
+    </main>
+  );
 };
 
 const Home = () => {
-  const { meetings } = useGetMeetingList();
-  const existMeetings = meetings.length !== 0;
   const { push } = useNavigator();
 
   useMeetingDetail();
@@ -46,7 +44,7 @@ const Home = () => {
 
   return (
     <>
-      {existMeetings && <FloatWrapper />}
+      <FloatWrapper />
       <View className="home">
         <CustomScreenHelmet
           appendMiddle={<img src={main_logo} />}
@@ -58,8 +56,7 @@ const Home = () => {
         <PageTitle />
         <Spacing height="2.4rem" />
         <Banner onClick={() => push('/guide/service')} />
-        <Spacing height="1.6rem" />
-        <MainContents existMeetings={existMeetings} />
+        <MainContents />
       </View>
     </>
   );


### PR DESCRIPTION
**변경사항**

<img width="342" alt="image" src="https://user-images.githubusercontent.com/56837413/156299505-b25adbb1-3bc3-40e7-91dc-83c2d2f58fbf.png">

지난 모임리스트를 분기해서 구분지어 보여주도록 수정했어요