### PR TITLE
서비스 종료 안내 페이지 구현 및 라우팅 처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,28 +7,12 @@ import { Navigator, Screen } from '@karrotframe/navigator';
 
 import '@karrotframe/navigator/index.css';
 
-import CreateGuidePage from './components/CreateGuidePage/CreateGuidePage';
-import CreatePage from './components/CreatePage';
-import Home from './components/Home';
-import LinkGeneratorPage from './components/LinkGeneratorPage';
-import MeetingDetailPage from './components/MeetingDetailPage';
-import MyPage from './components/MyPage';
-import GuidePage from './components/ServiceGuidePage/GuidePage';
+import CloseServicePage from './components/CloseServicePage/CloseServicePage';
 import useMini from './hook/useMini';
 import ToastContainer from './lib/Toast/components/ToastContainer';
 import { carrotTheme } from './style/carrotTheme';
 import { app } from './util/firebase';
 import { checkMobileType } from './util/utils';
-const NotFoundPage = React.lazy(() => import('./components/NotFoundPage'));
-const NotServiceRegionPage = React.lazy(
-  () => import('./components/NotServiceRegionPage'),
-);
-const QuitMeetingPage = React.lazy(
-  () => import('./components/QuitMeetingPage'),
-);
-const AgoraPage = React.lazy(() => import('./components/MeetingPage'));
-const RedirectPage = React.lazy(() => import('./components/RedirectPage'));
-const ShortURLPage = React.lazy(() => import('./components/ShortURLPage'));
 
 const NavigatorStyle = css`
   --kf_navigator_navbar-height: 5.6rem !important;
@@ -52,7 +36,8 @@ const App = () => {
           onClose={ejectApp}
           className={NavigatorStyle}
         >
-          <Screen path="/" component={Home} />
+          <Screen path="*" component={CloseServicePage} />
+          {/* <Screen path="/" component={Home} />
           <Screen path="/generator" component={LinkGeneratorPage} />
           <Screen path="/guide/create" component={CreateGuidePage} />
           <Screen path="/guide/service" component={GuidePage} />
@@ -64,7 +49,7 @@ const App = () => {
           <Screen path="/agora/quit" component={QuitMeetingPage} />
           <Screen path="/redirect" component={RedirectPage} />
           <Screen path="/short" component={ShortURLPage} />
-          <Screen path="*" component={NotFoundPage} />
+          <Screen path="*" component={NotFoundPage} /> */}
         </Navigator>
       </ToastContainer>
     </ThemeProvider>

--- a/src/components/CloseServicePage/CloseServicePage.tsx
+++ b/src/components/CloseServicePage/CloseServicePage.tsx
@@ -1,0 +1,79 @@
+import React, { useCallback } from 'react';
+
+import styled from '@emotion/styled';
+import mini from '@util/mini';
+import { getQueryString } from '@util/utils';
+
+import CustomScreenHelmet from '../common/CustomScreenHelmet';
+import Spacing from '../Home/components/Spacing';
+
+function CloseServicePage() {
+  const goBackHandler = useCallback(() => {
+    const withScheme = getQueryString(
+      window.location.hash.substring(window.location.hash.indexOf('?')),
+      'scheme',
+    );
+    if (!withScheme) mini.close();
+  }, []);
+
+  return (
+    <Page>
+      <CustomScreenHelmet onCustomCloseButton={goBackHandler} />
+
+      <Title>
+        <EmphasisTitle>랜선동네모임</EmphasisTitle> 베타서비스가 종료되었어요.
+      </Title>
+      <Spacing height="2.4rem" />
+      <Text>
+        그동안 관심을 가지고 랜선동네모임을 이용해주신 여러분께 감사드려요.
+        앞으로 들어올 새로운 서비스를 기대해주세요!
+      </Text>
+    </Page>
+  );
+}
+
+const Page = styled.div`
+  height: 100%;
+  padding: 0 2.4rem;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Title = styled.span`
+  font-family: 'HGSoftGGothicssi_Pro_80g';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 28px;
+  line-height: 120%;
+
+  text-align: center;
+  letter-spacing: -0.02em;
+  word-break: keep-all;
+
+  color: ${({ theme }) => theme.colors.$gray700};
+`;
+
+const EmphasisTitle = styled(Title)`
+  color: #fe8745;
+`;
+
+const Text = styled.span`
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 1.6rem;
+  line-height: 2.2rem;
+
+  display: flex;
+  align-items: center;
+  text-align: center;
+  letter-spacing: -0.02rem;
+
+  color: ${({ theme }) => theme.colors.$gray700};
+  word-break: keep-all;
+`;
+
+export default CloseServicePage;


### PR DESCRIPTION
**변경사항** 
<img width="200" alt="image" src="https://user-images.githubusercontent.com/56837413/158113732-42910025-a6e2-41cc-a093-9a3771e195db.png">

- 서비스 종료 안내 페이지를 추가했어요.
- 모든 url 라우팅에 대해 서비스 종료 안내 페이지로 이동되도록 수정했어요.